### PR TITLE
release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.13.2 (2020-12-09)
+
+BUG FIXES:
+
+* replace symlink to executable with identical copy
+  - `gem build` produces broken symlinks; unsupported
+
 ## 0.13.1 (2020-12-09)
 
 BUG FIXES:

--- a/exe/td
+++ b/exe/td
@@ -1,1 +1,11 @@
-terradactyl
+#!/usr/bin/env ruby
+
+require 'terradactyl'
+
+trap 'SIGINT' do
+  puts
+  puts 'Caught Interrupt. Exiting ...'
+  exit 1
+end
+
+Terradactyl::CLI.start

--- a/lib/terradactyl/version.rb
+++ b/lib/terradactyl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Terradactyl
-  VERSION = '0.13.1'
+  VERSION = '0.13.2'
 end


### PR DESCRIPTION
* replace symlink to executable with identical copy
  - `gem build` produces broken symlinks; unsupported