### PR TITLE
Release 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.15.3 (2021-05-14)
+
+BUG FIXES:
+
+* fix `auto-approve` on `destroy` subcommand for Terraform version 0.15
+* update all tests to use latest minor rev
+
 ## 0.15.2 (2021-05-02)
 
 NEW FEATURES:

--- a/lib/terradactyl/config.rb
+++ b/lib/terradactyl/config.rb
@@ -26,7 +26,7 @@ module Terradactyl
             input: false
           destroy:
             parallelism: 5
-            force: true
+            auto_approve: true
         environment:
           TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugins
         misc:

--- a/lib/terradactyl/version.rb
+++ b/lib/terradactyl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Terradactyl
-  VERSION = '0.15.2'
+  VERSION = '0.15.3'
 end

--- a/spec/fixtures/stacks/rev011/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev011/terradactyl.yaml
@@ -1,4 +1,4 @@
 ---
 terradactyl:
   terraform:
-    version: 0.11.14
+    version: 0.11.15

--- a/spec/fixtures/stacks/rev012/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev012/terradactyl.yaml
@@ -1,4 +1,4 @@
 ---
 terradactyl:
   terraform:
-    version: ~> 0.12.30
+    version: ~> 0.12.31

--- a/spec/fixtures/stacks/rev013/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev013/terradactyl.yaml
@@ -1,4 +1,4 @@
 ---
 terradactyl:
   terraform:
-    version: ~> 0.13.6
+    version: ~> 0.13.7

--- a/spec/fixtures/stacks/rev014/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev014/terradactyl.yaml
@@ -1,4 +1,4 @@
 ---
 terradactyl:
   terraform:
-    version: ~> 0.14.10
+    version: ~> 0.14.11

--- a/spec/fixtures/stacks/rev015/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev015/terradactyl.yaml
@@ -1,4 +1,4 @@
 ---
 terradactyl:
   terraform:
-    version: ~> 0.15.0
+    version: ~> 0.15.3

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -3,7 +3,7 @@ module Helpers
     def terraform_test_matrix
       {
         rev011: {
-          version: '~> 0.11.14',
+          version: '~> 0.11.15',
           upgradeable: true,
           artifacts: {
             plan:          'rev011.tfout',
@@ -17,7 +17,7 @@ module Helpers
           }
         },
         rev012: {
-          version: '~> 0.12.30',
+          version: '~> 0.12.31',
           upgradeable: true,
           artifacts: {
             plan:          'rev012.tfout',
@@ -31,7 +31,7 @@ module Helpers
           }
         },
         rev013: {
-          version: '~> 0.13.6',
+          version: '~> 0.13.7',
           upgradeable: true,
           artifacts: {
             plan:          'rev013.tfout',
@@ -45,7 +45,7 @@ module Helpers
           }
         },
         rev014: {
-          version: '~> 0.14.10',
+          version: '~> 0.14.11',
           upgradeable: true,
           artifacts: {
             plan:          'rev014.tfout',
@@ -59,7 +59,7 @@ module Helpers
           }
         },
         rev015: {
-          version: '~> 0.15.0',
+          version: '~> 0.15.3',
           upgradeable: false,
           artifacts: {
             plan:          'rev015.tfout',
@@ -135,7 +135,7 @@ module Helpers
   end
 
   def terraform_legacy
-    '0.11.14'
+    terraform_resolve('~> 0.11.0')
   end
 
   def terraform_latest


### PR DESCRIPTION
* fix `auto-approve` on `destroy` subcommand for Terraform version 0.15
* update all tests to use latest minor rev