### PR TITLE
Release 1.2.0 - Add terraform 1.2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.2.0 (2022-05-18)
+
+NEW FEATURES:
+
+* add support for Terraform version '~> 1.2.0`
+
+BUG FIX:
+
+* fix CHANGELOG.md URL in gemspec
+
 ## 1.1.2 (2021-01-05)
 
 BUG FIX:

--- a/lib/terradactyl/commands.rb
+++ b/lib/terradactyl/commands.rb
@@ -419,6 +419,21 @@ module Terradactyl
         Terraform::Rev1_01::PlanFileParser
       end
     end
+    module Rev1_02
+      class << self
+        def upgradeable?
+          false
+        end
+      end
+
+      include Terraform::Commands
+
+      private
+
+      def parser
+        Terraform::Rev1_02::PlanFileParser
+      end
+    end
   end
   # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/terradactyl/version.rb
+++ b/lib/terradactyl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Terradactyl
-  VERSION = '1.1.2'
+  VERSION = '1.2.0'
 end

--- a/spec/fixtures/stacks/rev1_02/terradactyl.yaml
+++ b/spec/fixtures/stacks/rev1_02/terradactyl.yaml
@@ -1,0 +1,4 @@
+---
+terradactyl:
+  terraform:
+    version: ~> 1.2.0

--- a/spec/fixtures/stacks/rev1_02/test.tf
+++ b/spec/fixtures/stacks/rev1_02/test.tf
@@ -1,0 +1,5 @@
+provider "null" {
+  version = "~> 3.0"
+}
+
+resource "null_resource" "foo" {}

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -88,9 +88,23 @@ module Helpers
         },
         rev1_01: {
           version: '~> 1.1.0',
-          upgradeable: false,
+          upgradeable: true,
           artifacts: {
             plan:          'rev1_01.tfout',
+            plan_file_obj: '.terraform/terradactyl.planfile.data',
+            init:          '.terraform',
+            apply:         'terraform.tfstate',
+            refresh:       'terraform.tfstate',
+            destroy:       'terraform.tfstate',
+            lint:          'unlinted.tf',
+            validate:      'invalid.tf',
+          }
+        },
+        rev1_02: {
+          version: '~> 1.2.0',
+          upgradeable: false,
+          artifacts: {
+            plan:          'rev1_02.tfout',
             plan_file_obj: '.terraform/terradactyl.planfile.data',
             init:          '.terraform',
             apply:         'terraform.tfstate',

--- a/terradactyl.gemspec
+++ b/terradactyl.gemspec
@@ -5,8 +5,8 @@ require 'terradactyl/version'
 Gem::Specification.new do |spec|
   spec.name        = "terradactyl"
   spec.version     = Terradactyl::VERSION
-  spec.authors     = ["Brian Warsing"]
-  spec.email       = ["brian.warsing@alida.com"]
+  spec.authors     = ["Brian Warsing", "Wade Peacock"]
+  spec.email       = ["brian.warsing@alida.com", "wade.peacock@alida.com"]
   spec.license     = 'MIT'
   spec.summary     = %{Manage a Terraform monorepo}
   spec.description = %{Provides facility to manage a large Terraform monorepo}
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri']      = spec.homepage
   spec.metadata['source_code_uri']   = spec.homepage
-  spec.metadata['changelog_uri']     = %{#{spec.homepage}/CHANGELOG.md}
+  spec.metadata['changelog_uri']     = %{#{spec.homepage}/blob/main/CHANGELOG.md}
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.required_ruby_version = '>= 2.5.0'
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deep_merge', '~> 1.2'
   spec.add_dependency 'bundler', '>= 1.16'
   spec.add_dependency 'rake', '>= 10.0'
-  spec.add_dependency 'terradactyl-terraform', '>= 1.1.0'
+  spec.add_dependency 'terradactyl-terraform', '>= 1.2.0'
 
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry', '~> 0.12'


### PR DESCRIPTION
1.2.0 (2022-05-18)

NEW FEATURES:

* add support for Terraform version `~> 1.2.0`

BUG FIX:

* fix CHANGELOG.md URL in gemspec